### PR TITLE
Added prop-types dependency and updated imports

### DIFF
--- a/modules/Broadcast.js
+++ b/modules/Broadcast.js
@@ -1,5 +1,6 @@
 import invariant from 'invariant'
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 const createBroadcast = (initialState) => {
   let listeners = []

--- a/modules/Subscriber.js
+++ b/modules/Subscriber.js
@@ -1,5 +1,6 @@
 import invariant from 'invariant'
-import React, { PropTypes } from 'react'
+import React from 'react'
+import PropTypes from 'prop-types'
 
 /**
  * A <Subscriber> pulls the value for a channel off of context.broadcasts

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint": "eslint modules"
   },
   "dependencies": {
-    "invariant": "^2.2.1"
+    "invariant": "^2.2.1",
+    "prop-types": "^15.5.6"
   },
   "peerDependencies": {
     "react": "15.x"


### PR DESCRIPTION
`React.PropTypes` have been deprecated in 15.5+ in favor of the new stand-alone [`prop-types`](https://www.npmjs.com/package/prop-types) package. (Read more [here](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html).)

This PR updates react-broadcast in order to avoid deprecation warnings for 15.5.0+ users.