### PR TITLE
chore(lib): Use brcast instead of createBroadcast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 umd
+node_modules

--- a/modules/Broadcast.js
+++ b/modules/Broadcast.js
@@ -1,31 +1,6 @@
 import invariant from 'invariant'
 import React, { PropTypes } from 'react'
-
-const createBroadcast = (initialState) => {
-  let listeners = []
-  let currentState = initialState
-
-  const getState = () =>
-    currentState
-
-  const setState = (state) => {
-    currentState = state
-    listeners.forEach(listener => listener(currentState))
-  }
-
-  const subscribe = (listener) => {
-    listeners.push(listener)
-
-    return () =>
-      listeners = listeners.filter(item => item !== listener)
-  }
-
-  return {
-    getState,
-    setState,
-    subscribe
-  }
-}
+import brcast from 'brcast'
 
 /**
  * A <Broadcast> provides a generic way for descendants to "subscribe"
@@ -51,7 +26,7 @@ class Broadcast extends React.Component {
     broadcasts: PropTypes.object.isRequired
   }
 
-  broadcast = createBroadcast(this.props.value)
+  broadcast = brcast(this.props.value)
 
   getChildContext() {
     return {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint modules"
   },
   "dependencies": {
+    "brcast": "^2.0.0",
     "invariant": "^2.2.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
Hi,

I've extracted the `createBroadcast` function into its own package.
https://www.npmjs.com/package/brcast
I use this patter a lot, so it made sense to me.

cheers